### PR TITLE
Fixed already initialized constant VERSION warning

### DIFF
--- a/monit.gemspec
+++ b/monit.gemspec
@@ -1,5 +1,6 @@
 # -*- encoding: utf-8 -*-
-require File.expand_path("../lib/monit/version", __FILE__)
+$:.unshift File.expand_path("../lib", __FILE__)
+require "monit/version"
 
 Gem::Specification.new do |gem|
   gem.authors     = ["Matias Korhonen"]


### PR DESCRIPTION
There was the same problem as here https://github.com/eventmachine/eventmachine/pull/284

Causing "lib/monit/version.rb:2: warning: already initialized constant VERSION"
