### PR TITLE
Force the port to be an integer

### DIFF
--- a/lib/monit/status.rb
+++ b/lib/monit/status.rb
@@ -38,7 +38,7 @@ module Monit
 
     # Construct the URL
     def url
-      url_params = { :host => @host, :port => @port, :path => "/_status", :query => "format=xml" }
+      url_params = { :host => @host, :port => @port.to_i, :path => "/_status", :query => "format=xml" }
       @ssl ? URI::HTTPS.build(url_params) : URI::HTTP.build(url_params)
     end
 


### PR DESCRIPTION
If, for some reason, the port provided in options isn't an integer, NET::HTTP will fail as it refuses it.

This makes the port an integer all the time, to fix the problem.
